### PR TITLE
Remove version from module path

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	appparams "github.com/firmachain/firmachain/v5/app/params"
+	appparams "github.com/firmachain/firmachain/app/params"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	math "cosmossdk.io/math"
@@ -51,7 +51,7 @@ import (
 	"github.com/cosmos/ibc-go/modules/capability"
 	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
-	"github.com/firmachain/firmachain/v5/app/openapiconsole"
+	"github.com/firmachain/firmachain/app/openapiconsole"
 
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
@@ -99,22 +99,22 @@ import (
 	ibcconnectiontypes "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
 	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 
-	upgrades "github.com/firmachain/firmachain/v5/app/upgrades"
-	v4 "github.com/firmachain/firmachain/v5/app/upgrades/v4"
-	v5 "github.com/firmachain/firmachain/v5/app/upgrades/v5"
-	"github.com/firmachain/firmachain/v5/client/docs"
+	upgrades "github.com/firmachain/firmachain/app/upgrades"
+	v4 "github.com/firmachain/firmachain/app/upgrades/v4"
+	v5 "github.com/firmachain/firmachain/app/upgrades/v5"
+	"github.com/firmachain/firmachain/client/docs"
 
 	ibcclienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
-	contractmodule "github.com/firmachain/firmachain/v5/x/contract"
-	contractmodulekeeper "github.com/firmachain/firmachain/v5/x/contract/keeper"
-	contractmoduletypes "github.com/firmachain/firmachain/v5/x/contract/types"
-	nftmodule "github.com/firmachain/firmachain/v5/x/nft"
-	nftmodulekeeper "github.com/firmachain/firmachain/v5/x/nft/keeper"
-	nftmoduletypes "github.com/firmachain/firmachain/v5/x/nft/types"
+	contractmodule "github.com/firmachain/firmachain/x/contract"
+	contractmodulekeeper "github.com/firmachain/firmachain/x/contract/keeper"
+	contractmoduletypes "github.com/firmachain/firmachain/x/contract/types"
+	nftmodule "github.com/firmachain/firmachain/x/nft"
+	nftmodulekeeper "github.com/firmachain/firmachain/x/nft/keeper"
+	nftmoduletypes "github.com/firmachain/firmachain/x/nft/types"
 
-	tokenmodule "github.com/firmachain/firmachain/v5/x/token"
-	tokenmodulekeeper "github.com/firmachain/firmachain/v5/x/token/keeper"
-	tokenmoduletypes "github.com/firmachain/firmachain/v5/x/token/types"
+	tokenmodule "github.com/firmachain/firmachain/x/token"
+	tokenmodulekeeper "github.com/firmachain/firmachain/x/token/keeper"
+	tokenmoduletypes "github.com/firmachain/firmachain/x/token/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 
@@ -161,7 +161,7 @@ import (
 	ibcfeekeeper "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/keeper"
 	ibcfeetypes "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/types"
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
-	"github.com/firmachain/firmachain/v5/app/keepers"
+	"github.com/firmachain/firmachain/app/keepers"
 
 	msgservice "github.com/cosmos/cosmos-sdk/types/msgservice"
 	proto "github.com/cosmos/gogoproto/proto"

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
 
-	"github.com/firmachain/firmachain/v5/app/apptesting"
+	"github.com/firmachain/firmachain/app/apptesting"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 )

--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -32,9 +32,9 @@ import (
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/firmachain/firmachain/v5/app"
-	apphelpers "github.com/firmachain/firmachain/v5/app/helpers"
-	appparams "github.com/firmachain/firmachain/v5/app/params"
+	"github.com/firmachain/firmachain/app"
+	apphelpers "github.com/firmachain/firmachain/app/helpers"
+	appparams "github.com/firmachain/firmachain/app/params"
 )
 
 func SetupApp(t *testing.T, chainId string, bondDenom string) (*app.App, sdk.Context, []AddressWithKeys) {

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -25,11 +25,11 @@ import (
 
 	stakinghelper "github.com/cosmos/cosmos-sdk/x/staking/testutil"
 
-	"github.com/firmachain/firmachain/v5/app"
-	appparams "github.com/firmachain/firmachain/v5/app/params"
-	contracttypes "github.com/firmachain/firmachain/v5/x/contract/types"
-	nfttypes "github.com/firmachain/firmachain/v5/x/nft/types"
-	tokentypes "github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/app"
+	appparams "github.com/firmachain/firmachain/app/params"
+	contracttypes "github.com/firmachain/firmachain/x/contract/types"
+	nfttypes "github.com/firmachain/firmachain/x/nft/types"
+	tokentypes "github.com/firmachain/firmachain/x/token/types"
 
 	header "cosmossdk.io/core/header"
 )

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	appparams "github.com/firmachain/firmachain/v5/app/params"
+	appparams "github.com/firmachain/firmachain/app/params"
 
 	"cosmossdk.io/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -25,10 +25,10 @@ import (
 
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 
-	contractmodulekeeper "github.com/firmachain/firmachain/v5/x/contract/keeper"
-	nftmodulekeeper "github.com/firmachain/firmachain/v5/x/nft/keeper"
+	contractmodulekeeper "github.com/firmachain/firmachain/x/contract/keeper"
+	nftmodulekeeper "github.com/firmachain/firmachain/x/nft/keeper"
 
-	tokenmodulekeeper "github.com/firmachain/firmachain/v5/x/token/keeper"
+	tokenmodulekeeper "github.com/firmachain/firmachain/x/token/keeper"
 
 	icacontrollerkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/keeper"
 	icahostkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/keeper"

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -5,7 +5,7 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/firmachain/firmachain/v5/app/keepers"
+	"github.com/firmachain/firmachain/app/keepers"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/app/upgrades/v4/constants.go
+++ b/app/upgrades/v4/constants.go
@@ -2,7 +2,7 @@ package v4
 
 import (
 	store "cosmossdk.io/store/types"
-	upgrades "github.com/firmachain/firmachain/v5/app/upgrades"
+	upgrades "github.com/firmachain/firmachain/app/upgrades"
 )
 
 // UpgradeName defines the on-chain upgrade name for the upgrade.

--- a/app/upgrades/v4/upgrades.go
+++ b/app/upgrades/v4/upgrades.go
@@ -9,7 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	"github.com/firmachain/firmachain/v5/app/keepers"
+	"github.com/firmachain/firmachain/app/keepers"
 )
 
 func CreateV0_4_0UpgradeHandler(

--- a/app/upgrades/v5/constants.go
+++ b/app/upgrades/v5/constants.go
@@ -11,7 +11,7 @@ import (
 
 	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
 	ibcfeetypes "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/types"
-	upgrades "github.com/firmachain/firmachain/v5/app/upgrades"
+	upgrades "github.com/firmachain/firmachain/app/upgrades"
 )
 
 // UpgradeName defines the on-chain upgrade name for the upgrade.

--- a/app/upgrades/v5/upgrade_test.go
+++ b/app/upgrades/v5/upgrade_test.go
@@ -7,8 +7,8 @@ import (
 	"cosmossdk.io/log"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/firmachain/firmachain/v5/app/apptesting"
-	v5 "github.com/firmachain/firmachain/v5/app/upgrades/v5"
+	"github.com/firmachain/firmachain/app/apptesting"
+	v5 "github.com/firmachain/firmachain/app/upgrades/v5"
 
 	module "github.com/cosmos/cosmos-sdk/types/module"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -16,7 +16,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 
-	appparams "github.com/firmachain/firmachain/v5/app/params"
+	appparams "github.com/firmachain/firmachain/app/params"
 )
 
 type UpgradeTestSuite struct {

--- a/app/upgrades/v5/upgrades.go
+++ b/app/upgrades/v5/upgrades.go
@@ -7,13 +7,13 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	appparams "github.com/firmachain/firmachain/v5/app/params"
+	appparams "github.com/firmachain/firmachain/app/params"
 
 	"cosmossdk.io/math"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/firmachain/firmachain/v5/app/keepers"
+	"github.com/firmachain/firmachain/app/keepers"
 
 	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v8/types"
 	ibchookstypes "github.com/cosmos/ibc-apps/modules/ibc-hooks/v8/types"

--- a/cmd/firmachaind/main.go
+++ b/cmd/firmachaind/main.go
@@ -5,7 +5,7 @@ import (
 
 	"cosmossdk.io/log"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
-	"github.com/firmachain/firmachain/v5/app"
+	"github.com/firmachain/firmachain/app"
 )
 
 func main() {

--- a/cmd/firmachaind/root.go
+++ b/cmd/firmachaind/root.go
@@ -34,8 +34,8 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	"github.com/firmachain/firmachain/v5/app"
-	appparams "github.com/firmachain/firmachain/v5/app/params"
+	"github.com/firmachain/firmachain/app"
+	appparams "github.com/firmachain/firmachain/app/params"
 
 	"cosmossdk.io/client/v2/autocli"
 	"cosmossdk.io/core/appmodule"

--- a/docker/colosseum/Dockerfile
+++ b/docker/colosseum/Dockerfile
@@ -9,14 +9,14 @@ RUN apt-get update && apt-get install -y git wget
 
 # Download from GitHub instead of using COPY
 RUN rm firmachain -rf
-RUN git clone https://github.com/firmachain/firmachain/v5 /firmachain
+RUN git clone https://github.com/firmachain/firmachain /firmachain
 WORKDIR "/firmachain"
 
 # Checkout a specific version
 # RUN git checkout v0.3.2
 RUN LEDGER_ENABLED=false make 
 
-RUN wget https://github.com/firmachain/firmachain/v5-testnet-colosseum/raw/main/genesis.json;
+RUN wget https://github.com/firmachain/firmachain-testnet-colosseum/raw/main/genesis.json;
 
 # Create final container
 FROM ubuntu:latest

--- a/docker/imperium/Dockerfile
+++ b/docker/imperium/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y git wget
 
 # Download from GitHub instead of using COPY
 RUN rm firmachain -rf
-RUN git clone https://github.com/firmachain/firmachain/v5 /firmachain
+RUN git clone https://github.com/firmachain/firmachain /firmachain
 WORKDIR "/firmachain"
 
 # Checkout a specific version
@@ -17,7 +17,7 @@ RUN git checkout v0.2.3
 RUN make 
 #RUN LEDGER_ENABLED=false make 
 
-RUN wget https://github.com/firmachain/firmachain/v5-devnet-imperium/raw/master/genesis.json;
+RUN wget https://github.com/firmachain/firmachain-devnet-imperium/raw/master/genesis.json;
 
 # Create final container
 FROM ubuntu:latest

--- a/docs/archive/join-the-colosseum-reward-testnet/README.md
+++ b/docs/archive/join-the-colosseum-reward-testnet/README.md
@@ -77,7 +77,7 @@ Re-enter keyring passphrase: XXXXXXXX
 genesis.json download
 
 ```
-wget https://github.com/firmachain/firmachain/v5-testnet-colosseum/raw/main/genesis.json
+wget https://github.com/firmachain/firmachain-testnet-colosseum/raw/main/genesis.json
 ```
 
 copy genesis.json from firmachain config folder

--- a/docs/general-guides/ledger/usage-on-firmachain-cli.md
+++ b/docs/general-guides/ledger/usage-on-firmachain-cli.md
@@ -26,7 +26,7 @@ sudo snap install go --classic
 #### 2. Install FirmaChain
 
 ```
-git clone https://github.com/firmachain/firmachain/v5.git
+git clone https://github.com/firmachain/firmachain.git
 
 cd firmachain/
 

--- a/docs/getting-started/install-firmachain/install.md
+++ b/docs/getting-started/install-firmachain/install.md
@@ -37,9 +37,9 @@ b59534ef087becc442f04a6cd42e4fc153c18bb7 firmachaind
 
 ### Ways 2. Download from Github Release page
 
-You can download a prebuilt binary from the link below. [https://github.com/firmachain/firmachain/v5/releases](https://github.com/firmachain/firmachain/v5/releases)​
+You can download a prebuilt binary from the link below. [https://github.com/firmachain/firmachain/releases](https://github.com/firmachain/firmachain/releases)​
 
-<figure><img src="../../.gitbook/assets/image (8).png" alt=""><figcaption><p><a href="https://github.com/firmachain/firmachain/v5/releases">https://github.com/firmachain/firmachain/v5/releases</a></p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/image (8).png" alt=""><figcaption><p><a href="https://github.com/firmachain/firmachain/releases">https://github.com/firmachain/firmachain/releases</a></p></figcaption></figure>
 
 Select, download and unzip a binary that suits your OS.\
 Please confirm whether you’ve downloaded the correct version, using the method provided in Ways 1.

--- a/docs/validator-guide/join-the-imperium-testnet.md
+++ b/docs/validator-guide/join-the-imperium-testnet.md
@@ -84,7 +84,7 @@ cp ./genesis.json ~/.firmachain/config/genesis.json
 
 #### P2P Setting
 
-We provide persistent peer node for P2P connection. You can find more details from [this link](https://github.com/firmachain/firmachain/v5-devnet-imperium).
+We provide persistent peer node for P2P connection. You can find more details from [this link](https://github.com/firmachain/firmachain-devnet-imperium).
 
 ```
 vi ~/.firmachain/config/config.toml

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/firmachain/firmachain/v5
+module github.com/firmachain/firmachain
 
 go 1.23.4
 

--- a/proto/firmachain/contract/contract_file.proto
+++ b/proto/firmachain/contract/contract_file.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package firmachain.contract;
 
-option go_package = "github.com/firmachain/firmachain/v5/x/contract/types";
+option go_package = "github.com/firmachain/firmachain/x/contract/types";
 
 // Contract file representation
 message ContractFile {

--- a/proto/firmachain/contract/contract_log.proto
+++ b/proto/firmachain/contract/contract_log.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package firmachain.contract;
 
-option go_package = "github.com/firmachain/firmachain/v5/x/contract/types";
+option go_package = "github.com/firmachain/firmachain/x/contract/types";
 
 // Contract log representation
 message ContractLog {

--- a/proto/firmachain/contract/genesis.proto
+++ b/proto/firmachain/contract/genesis.proto
@@ -4,7 +4,7 @@ package firmachain.contract;
 import "firmachain/contract/contract_file.proto";
 import "firmachain/contract/contract_log.proto";
 
-option go_package = "github.com/firmachain/firmachain/v5/x/contract/types";
+option go_package = "github.com/firmachain/firmachain/x/contract/types";
 
 // GenesisState defines the contract module's genesis state.
 message GenesisState {

--- a/proto/firmachain/contract/query.proto
+++ b/proto/firmachain/contract/query.proto
@@ -6,7 +6,7 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 import "firmachain/contract/contract_file.proto";
 import "firmachain/contract/contract_log.proto";
 
-option go_package = "github.com/firmachain/firmachain/v5/x/contract/types";
+option go_package = "github.com/firmachain/firmachain/x/contract/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/firmachain/contract/tx.proto
+++ b/proto/firmachain/contract/tx.proto
@@ -6,7 +6,7 @@ import "firmachain/contract/contract_log.proto";
 import "cosmos/msg/v1/msg.proto";
 import "amino/amino.proto";
 
-option go_package = "github.com/firmachain/firmachain/v5/x/contract/types";
+option go_package = "github.com/firmachain/firmachain/x/contract/types";
 
 // Msg defines the Msg service.
 service Msg {

--- a/proto/firmachain/nft/genesis.proto
+++ b/proto/firmachain/nft/genesis.proto
@@ -3,7 +3,7 @@ package firmachain.nft;
 
 import "firmachain/nft/nft_item.proto";
 
-option go_package = "github.com/firmachain/firmachain/v5/x/nft/types";
+option go_package = "github.com/firmachain/firmachain/x/nft/types";
 
 // GenesisState defines the nft module's genesis state.
 message GenesisState {

--- a/proto/firmachain/nft/nft_item.proto
+++ b/proto/firmachain/nft/nft_item.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package firmachain.nft;
 
-option go_package = "github.com/firmachain/firmachain/v5/x/nft/types";
+option go_package = "github.com/firmachain/firmachain/x/nft/types";
 
 // An NFT Item
 message NftItem {

--- a/proto/firmachain/nft/query.proto
+++ b/proto/firmachain/nft/query.proto
@@ -5,7 +5,7 @@ import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "firmachain/nft/nft_item.proto";
 
-option go_package = "github.com/firmachain/firmachain/v5/x/nft/types";
+option go_package = "github.com/firmachain/firmachain/x/nft/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/firmachain/nft/tx.proto
+++ b/proto/firmachain/nft/tx.proto
@@ -3,7 +3,7 @@ package firmachain.nft;
 
 import "firmachain/nft/nft_item.proto";
 
-option go_package = "github.com/firmachain/firmachain/v5/x/nft/types";
+option go_package = "github.com/firmachain/firmachain/x/nft/types";
 import "cosmos/msg/v1/msg.proto";
 import "amino/amino.proto";
 

--- a/proto/firmachain/token/genesis.proto
+++ b/proto/firmachain/token/genesis.proto
@@ -4,7 +4,7 @@ package firmachain.token;
 import "firmachain/token/token_data.proto";
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/firmachain/firmachain/v5/x/token/types";
+option go_package = "github.com/firmachain/firmachain/x/token/types";
 
 // GenesisState defines the token module's genesis state.
 message GenesisState {

--- a/proto/firmachain/token/query.proto
+++ b/proto/firmachain/token/query.proto
@@ -6,7 +6,7 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 import "firmachain/token/token_data.proto";
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/firmachain/firmachain/v5/x/token/types";
+option go_package = "github.com/firmachain/firmachain/x/token/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/firmachain/token/token_data.proto
+++ b/proto/firmachain/token/token_data.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package firmachain.token;
 
 
-option go_package = "github.com/firmachain/firmachain/v5/x/token/types";
+option go_package = "github.com/firmachain/firmachain/x/token/types";
 
 
 // Token data representation

--- a/proto/firmachain/token/tx.proto
+++ b/proto/firmachain/token/tx.proto
@@ -3,7 +3,7 @@ package firmachain.token;
 
 import "firmachain/token/token_data.proto";
 
-option go_package = "github.com/firmachain/firmachain/v5/x/token/types";
+option go_package = "github.com/firmachain/firmachain/x/token/types";
 import "cosmos/msg/v1/msg.proto";
 import "amino/amino.proto";
 

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 # FirmaChain
 
-[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/firmachain/firmachain)](https://github.com/firmachain/firmachain/v5/releases)
-[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/firmachain/firmachain/v5/blob/master/LICENSE)
-[![Go Reference](https://pkg.go.dev/badge/github.com/firmachain/firmachain/v5/.svg)](https://pkg.go.dev/github.com/firmachain/firmachain/v5/)
-[![report](https://goreportcard.com/badge/github.com/firmachain/firmachain/v5)](https://goreportcard.com/report/github.com/firmachain/firmachain/v5)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/firmachain/firmachain)](https://github.com/firmachain/firmachain/releases)
+[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/firmachain/firmachain/blob/master/LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/firmachain/firmachain/.svg)](https://pkg.go.dev/github.com/firmachain/firmachain/)
+[![report](https://goreportcard.com/badge/github.com/firmachain/firmachain)](https://goreportcard.com/report/github.com/firmachain/firmachain)
 ![Lines of code](https://img.shields.io/tokei/lines/github/firmachain/firmachain)
 
-![ci](https://github.com/firmachain/firmachain/v5/actions/workflows/test.yml/badge.svg)
+![ci](https://github.com/firmachain/firmachain/actions/workflows/test.yml/badge.svg)
 <a href="https://codecov.io/gh/firmachain/firmachain">
     <img src="https://codecov.io/gh/firmachain/firmachain/branch/master/graph/badge.svg">
 </a>
@@ -48,7 +48,7 @@ Currently available tags:
 ### Build Guide : using make ###
 
 ```bash
-git clone https://github.com/firmachain/firmachain/v5
+git clone https://github.com/firmachain/firmachain
 cd firmachain
 git checkout (desired tags)
 
@@ -78,9 +78,9 @@ If you are interested, please contact us through contact@firmachain.org
 </br>
 
 ## Ecosystem
-- [Firmachain Block Explorer](https://github.com/firmachain/firmachain/v5-explorer)
+- [Firmachain Block Explorer](https://github.com/firmachain/firmachain-explorer)
 - [Firma Station](https://github.com/FirmaChain/firma-station) 
-- [Firmachain Faucet (Testnet, Imperium-4)](https://github.com/firmachain/firmachain/v5-faucet) 
+- [Firmachain Faucet (Testnet, Imperium-4)](https://github.com/firmachain/firmachain-faucet) 
 
 </br>
 

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -20,7 +20,7 @@ buf generate --template ./proto/buf.gen.gogo.yaml
 # move proto files to the right places
 if [ -d "./github.com" ]; then
     echo "Copying generated files..."
-    cp -r ./github.com/firmachain/firmachain/v5/x/* x/
+    cp -r ./github.com/firmachain/firmachain/x/* x/
     rm -rf ./github.com
 else
     echo "No files in ./github.com, skipping..."

--- a/x/contract/client/cli/query.go
+++ b/x/contract/client/cli/query.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module

--- a/x/contract/client/cli/query_contract_file.go
+++ b/x/contract/client/cli/query_contract_file.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 	"github.com/spf13/cobra"
 )
 

--- a/x/contract/client/cli/query_contract_list_from_hash.go
+++ b/x/contract/client/cli/query_contract_list_from_hash.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/contract/client/cli/query_contract_log.go
+++ b/x/contract/client/cli/query_contract_log.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 	"github.com/spf13/cobra"
 )
 

--- a/x/contract/client/cli/query_is_contract_owner.go
+++ b/x/contract/client/cli/query_is_contract_owner.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/contract/client/cli/tx.go
+++ b/x/contract/client/cli/tx.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 var (

--- a/x/contract/client/cli/tx_contract_file.go
+++ b/x/contract/client/cli/tx_contract_file.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 func CmdCreateContractFile() *cobra.Command {

--- a/x/contract/client/cli/tx_contract_log.go
+++ b/x/contract/client/cli/tx_contract_log.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 func CmdAddContractLog() *cobra.Command {

--- a/x/contract/keeper/contract_file.go
+++ b/x/contract/keeper/contract_file.go
@@ -4,7 +4,7 @@ import (
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 // SetContractFile set a specific contractFile in the store from its index

--- a/x/contract/keeper/contract_log.go
+++ b/x/contract/keeper/contract_log.go
@@ -6,7 +6,7 @@ import (
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 func (k Keeper) AppendContractLog(ctx sdk.Context, contractLog types.ContractLog) uint64 {

--- a/x/contract/keeper/genesis.go
+++ b/x/contract/keeper/genesis.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 // InitGenesis initializes the capability module's state from a provided genesis

--- a/x/contract/keeper/grpc_query.go
+++ b/x/contract/keeper/grpc_query.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/contract/keeper/grpc_query_contract_file.go
+++ b/x/contract/keeper/grpc_query_contract_file.go
@@ -6,7 +6,7 @@ import (
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/x/contract/keeper/grpc_query_contract_log.go
+++ b/x/contract/keeper/grpc_query_contract_log.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/x/contract/keeper/grpc_query_get_contract_list_from_hash.go
+++ b/x/contract/keeper/grpc_query_get_contract_list_from_hash.go
@@ -5,7 +5,7 @@ import (
 
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/x/contract/keeper/grpc_query_is_contract_owner.go
+++ b/x/contract/keeper/grpc_query_is_contract_owner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/x/contract/keeper/keeper.go
+++ b/x/contract/keeper/keeper.go
@@ -8,7 +8,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 type (

--- a/x/contract/keeper/msg_server.go
+++ b/x/contract/keeper/msg_server.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 type msgServer struct {

--- a/x/contract/keeper/msg_server_contract_file.go
+++ b/x/contract/keeper/msg_server_contract_file.go
@@ -7,7 +7,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 func (ms msgServer) CreateContractFile(goCtx context.Context, msg *types.MsgCreateContractFile) (*types.MsgCreateContractFileResponse, error) {

--- a/x/contract/keeper/msg_server_contract_log.go
+++ b/x/contract/keeper/msg_server_contract_log.go
@@ -6,7 +6,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 )
 
 func (ms msgServer) AddContractLog(goCtx context.Context, msg *types.MsgAddContractLog) (*types.MsgAddContractLogResponse, error) {

--- a/x/contract/module.go
+++ b/x/contract/module.go
@@ -14,9 +14,9 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/firmachain/firmachain/v5/x/contract/client/cli"
-	"github.com/firmachain/firmachain/v5/x/contract/keeper"
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/client/cli"
+	"github.com/firmachain/firmachain/x/contract/keeper"
+	"github.com/firmachain/firmachain/x/contract/types"
 	grpc "google.golang.org/grpc"
 )
 

--- a/x/contract/types/genesis_test.go
+++ b/x/contract/types/genesis_test.go
@@ -3,7 +3,7 @@ package types_test
 import (
 	"testing"
 
-	"github.com/firmachain/firmachain/v5/x/contract/types"
+	"github.com/firmachain/firmachain/x/contract/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/x/nft/client/cli/query.go
+++ b/x/nft/client/cli/query.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module

--- a/x/nft/client/cli/query_balance_of.go
+++ b/x/nft/client/cli/query_balance_of.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/nft/client/cli/query_nft_id_list_of_owner.go
+++ b/x/nft/client/cli/query_nft_id_list_of_owner.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/nft/client/cli/query_nft_item.go
+++ b/x/nft/client/cli/query_nft_item.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 	"github.com/spf13/cobra"
 )
 

--- a/x/nft/client/cli/tx.go
+++ b/x/nft/client/cli/tx.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 var (

--- a/x/nft/client/cli/tx_burn.go
+++ b/x/nft/client/cli/tx_burn.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/nft/client/cli/tx_mint.go
+++ b/x/nft/client/cli/tx_mint.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/nft/client/cli/tx_transfer.go
+++ b/x/nft/client/cli/tx_transfer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/nft/keeper/genesis.go
+++ b/x/nft/keeper/genesis.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 // InitGenesis initializes the capability module's state from a provided genesis

--- a/x/nft/keeper/grpc_query.go
+++ b/x/nft/keeper/grpc_query.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/nft/keeper/grpc_query_balance_of.go
+++ b/x/nft/keeper/grpc_query_balance_of.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/x/nft/keeper/grpc_query_nft_id_list_of_owner.go
+++ b/x/nft/keeper/grpc_query_nft_id_list_of_owner.go
@@ -6,7 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/x/nft/keeper/grpc_query_nft_item.go
+++ b/x/nft/keeper/grpc_query_nft_item.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/x/nft/keeper/keeper.go
+++ b/x/nft/keeper/keeper.go
@@ -8,7 +8,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 type (

--- a/x/nft/keeper/msg_server.go
+++ b/x/nft/keeper/msg_server.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 type msgServer struct {

--- a/x/nft/keeper/msg_server_burn.go
+++ b/x/nft/keeper/msg_server_burn.go
@@ -7,7 +7,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 func (ms msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.MsgBurnResponse, error) {

--- a/x/nft/keeper/msg_server_mint.go
+++ b/x/nft/keeper/msg_server_mint.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 func (ms msgServer) Mint(goCtx context.Context, msg *types.MsgMint) (*types.MsgMintResponse, error) {

--- a/x/nft/keeper/msg_server_transfer.go
+++ b/x/nft/keeper/msg_server_transfer.go
@@ -7,7 +7,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 func (ms msgServer) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.MsgTransferResponse, error) {

--- a/x/nft/keeper/nft_item.go
+++ b/x/nft/keeper/nft_item.go
@@ -7,7 +7,7 @@ import (
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 )
 
 func (k Keeper) AppendNftItem(

--- a/x/nft/module.go
+++ b/x/nft/module.go
@@ -14,9 +14,9 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/firmachain/firmachain/v5/x/nft/client/cli"
-	"github.com/firmachain/firmachain/v5/x/nft/keeper"
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/client/cli"
+	"github.com/firmachain/firmachain/x/nft/keeper"
+	"github.com/firmachain/firmachain/x/nft/types"
 	grpc "google.golang.org/grpc"
 )
 

--- a/x/nft/types/genesis_test.go
+++ b/x/nft/types/genesis_test.go
@@ -3,7 +3,7 @@ package types_test
 import (
 	"testing"
 
-	"github.com/firmachain/firmachain/v5/x/nft/types"
+	"github.com/firmachain/firmachain/x/nft/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/x/token/client/cli/query.go
+++ b/x/token/client/cli/query.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module

--- a/x/token/client/cli/query_get_token_list.go
+++ b/x/token/client/cli/query_get_token_list.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/token/client/cli/query_token_data.go
+++ b/x/token/client/cli/query_token_data.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 func CmdListTokenData() *cobra.Command {

--- a/x/token/client/cli/tx.go
+++ b/x/token/client/cli/tx.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 var (

--- a/x/token/client/cli/tx_burn.go
+++ b/x/token/client/cli/tx_burn.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/token/client/cli/tx_create_token.go
+++ b/x/token/client/cli/tx_create_token.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/token/client/cli/tx_mint.go
+++ b/x/token/client/cli/tx_mint.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/token/client/cli/tx_update_token_uri.go
+++ b/x/token/client/cli/tx_update_token_uri.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 var _ = strconv.Itoa(0)

--- a/x/token/keeper/genesis.go
+++ b/x/token/keeper/genesis.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 // InitGenesis initializes the capability module's state from a provided genesis

--- a/x/token/keeper/grpc_query.go
+++ b/x/token/keeper/grpc_query.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/token/keeper/grpc_query_get_token_list.go
+++ b/x/token/keeper/grpc_query_get_token_list.go
@@ -5,7 +5,7 @@ import (
 
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/x/token/keeper/grpc_query_token_data.go
+++ b/x/token/keeper/grpc_query_token_data.go
@@ -6,7 +6,7 @@ import (
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/x/token/keeper/keeper.go
+++ b/x/token/keeper/keeper.go
@@ -8,7 +8,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 type (

--- a/x/token/keeper/msg_server.go
+++ b/x/token/keeper/msg_server.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 type msgServer struct {

--- a/x/token/keeper/msg_server_burn.go
+++ b/x/token/keeper/msg_server_burn.go
@@ -7,7 +7,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 func (ms msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.MsgBurnResponse, error) {

--- a/x/token/keeper/msg_server_create_token.go
+++ b/x/token/keeper/msg_server_create_token.go
@@ -7,7 +7,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 func (ms msgServer) CreateToken(goCtx context.Context, msg *types.MsgCreateToken) (*types.MsgCreateTokenResponse, error) {

--- a/x/token/keeper/msg_server_mint.go
+++ b/x/token/keeper/msg_server_mint.go
@@ -8,7 +8,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 func (ms msgServer) Mint(goCtx context.Context, msg *types.MsgMint) (*types.MsgMintResponse, error) {

--- a/x/token/keeper/msg_server_update_token_uri.go
+++ b/x/token/keeper/msg_server_update_token_uri.go
@@ -6,7 +6,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 func (ms msgServer) UpdateTokenURI(goCtx context.Context, msg *types.MsgUpdateTokenURI) (*types.MsgUpdateTokenURIResponse, error) {

--- a/x/token/keeper/token_data.go
+++ b/x/token/keeper/token_data.go
@@ -10,7 +10,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/types"
 )
 
 const (

--- a/x/token/module.go
+++ b/x/token/module.go
@@ -14,9 +14,9 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/firmachain/firmachain/v5/x/token/client/cli"
-	"github.com/firmachain/firmachain/v5/x/token/keeper"
-	"github.com/firmachain/firmachain/v5/x/token/types"
+	"github.com/firmachain/firmachain/x/token/client/cli"
+	"github.com/firmachain/firmachain/x/token/keeper"
+	"github.com/firmachain/firmachain/x/token/types"
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
This PR:
- removes the `v5` version tag from the global Firmachain module name