### PR TITLE
Release Firmachain v0.5.0-patch

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -902,6 +902,15 @@ func New(
 	app.setupUpgradeHandlers(app.configurator)
 	app.setupUpgradeStoreLoaders()
 
+	// register snapshot extensions (e.g. CosmWasm) so state sync restores full state
+	if sm := app.SnapshotManager(); sm != nil {
+		if err := sm.RegisterExtensions(
+			wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.AppKeepers.WasmKeeper),
+		); err != nil {
+			panic("failed to register snapshot extension: " + err.Error())
+		}
+	}
+	
 	// SDK v47 - since we do not use dep inject, this gives us access to newer gRPC services.
 	autocliv1.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.mm.Modules))
 	reflectionSvc, err := runtimeservices.NewReflectionService()


### PR DESCRIPTION
# Pull Request for Firmachain v0.5.0-patch Release

## Updates

### Chain Binary
- Upgrade: `v0.5.0` → `v0.5.0-patch`
- Since this patch is a **non-breaking, non-governance upgrade**, the chain version stays at `v0.5.0`

### Patches
**State-Sync AppHash Error Fix**
- #11  
- **Issue**: Nodes bootstrapping via state-sync would halt with AppHash mismatch on smart contract transactions.
- **Root Cause**: CosmWasm contract data (code, pinned codes, checkpoints) was missing from state-sync snapshots.
- **Solution**: Patch ensures CosmWasm data is included in state-sync snapshots.

### Requirements

- **Go**: v1.21 (same as v0.5.0)

### Tests

- **Local**: Unit Tests, CLI Commands  
- **Devnet**: Unit Tests, CLI Commands, E2E Tests  
- **Testnet (Imperium-4)**: Unit Tests, CLI Commands, E2E Tests, Smart Contract Transactions (state-sync validation)


## Detailed Description

This patch is a **non-breaking, non-governance upgrade** that resolves AppHash mismatch errors observed on state-synced nodes when processing smart contract transactions.  

Key changes:
- Ensures state-sync snapshots now include **all CosmWasm contract data**:
  - Contract code
  - Pinned codes
  - Checkpoints
- Prevents divergence between fresh state-synced nodes and long-running nodes.
- Stabilizes network bootstrap process and smart contract execution.


## Who Should Upgrade

- **Required**:
  - State-sync providers (to generate valid snapshots)
  - State-sync users (to restore successfully from snapshots)

- **Recommended**:
  - All validators and full nodes (to prevent future issues and improve stability)
