### PR TITLE
Release Firmachain v0.5.1-patch

### DIFF
--- a/cmd/firmachaind/root.go
+++ b/cmd/firmachaind/root.go
@@ -58,9 +58,8 @@ var emptyWasmOpts []wasmkeeper.Option
 var tempDir = func() string {
 	dir, err := os.MkdirTemp("", ".firmachain")
 	if err != nil {
-		dir = app.DefaultNodeHome
+		panic("failed to create temp dir: " + err.Error())
 	}
-	defer os.RemoveAll(dir)
 
 	return dir
 }
@@ -74,6 +73,11 @@ func NewRootCmd() *cobra.Command {
 	// we "pre"-instantiate the application for getting the injected/configured encoding configuration
 	initAppOptions := viper.New()
 	tempDir := tempDir()
+
+	// cleanup temp dir after we are done with the tempApp, so we don't leave behind a
+	// new temporary directory for every invocation. See https://github.com/CosmWasm/wasmd/issues/2017
+	defer os.RemoveAll(tempDir)
+
 	initAppOptions.Set(flags.FlagHome, tempDir)
 	tempApp := app.New(
 		log.NewNopLogger(),


### PR DESCRIPTION
# Pull Request for Firmachain v0.5.1-patch Release

## Updates

### Chain Binary
- Upgrade: `v0.5.1` → `v0.5.1-patch`
- Since this patch is a **non-breaking, non-governance upgrade**, the chain version stays at `v0.5.1`

### Patches
**TempDir Cleanup Fix**
- #20 
- **Issue**: Each `firmachaind` execution created a new `/tmp/.firmachainXXXXXXX` directory, which was never removed; causing inode growth and unnecessary disk usage, even for simple commands like `firmachaind status`.
- **Root Cause**: CosmWasm’s temporary app initialization flow did not clean up WASM temp directories after command execution.
- **Solution**: Added cleanup process during tempApp initialization to ensure directories are deleted properly.

### Requirements

- **Go**: v1.21 (same as v0.5.1)

### Tests

- **Local**: Unit Tests, CLI Commands  
- **Devnet**: Unit Tests, CLI Commands, E2E Tests  
- **Testnet (Imperium-4)**: Unit Tests, CLI Commands, E2E Tests, Smart Contract Transactions (state-sync validation)


## Detailed Description

This patch resolves the CosmWasm temp directory leakage that caused persistent `/tmp/.firmachain*` artifacts.

Key improvements:
- Ensures temporary WASM directories are fully cleaned after each command.
- Prevents inode exhaustion and improves node environment stability.


## Who Should Upgrade

- **Required**:
  -  Node operators experiencing growing `/tmp/.firmachain*` directories

- **Recommended**:
  - All validators and full nodes (upgrading avoids future disk bloat and improves overall reliability)
