### PR TITLE
FirmaChain v0.5.1-patch2 for colosseum mainnet (Official Release)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	cosmossdk.io/x/tx v1.1.0
 	cosmossdk.io/x/upgrade v0.1.4
 	github.com/CosmWasm/wasmd v0.54.3
-	github.com/cometbft/cometbft v0.38.18
+	github.com/cometbft/cometbft v0.38.21
 	github.com/cosmos/cosmos-db v1.1.3
 	github.com/cosmos/cosmos-sdk v0.50.14
 	github.com/cosmos/gogoproto v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/coinbase/kryptology v1.8.0/go.mod h1:RYXOAPdzOGUe3qlSFkMGn58i3xUA8hmxYHksuq+8ciI=
 github.com/coinbase/rosetta-sdk-go v0.7.9 h1:lqllBjMnazTjIqYrOGv8h8jxjg9+hJazIGZr9ZvoCcA=
 github.com/coinbase/rosetta-sdk-go v0.7.9/go.mod h1:0/knutI7XGVqXmmH4OQD8OckFrbQ8yMsUZTG7FXCR2M=
-github.com/cometbft/cometbft v0.38.18 h1:1ZHYMdu0S75YxFM13LlPXnOwiIpUW5z9TKMQtTIALpw=
-github.com/cometbft/cometbft v0.38.18/go.mod h1:PlOQgf3jQorep+g6oVnJgtP65TJvBJoLiXjGaMdNxBE=
+github.com/cometbft/cometbft v0.38.21 h1:qcIJSH9LiwU5s6ZgKR5eRbsLNucbubfraDs5bzgjtOI=
+github.com/cometbft/cometbft v0.38.21/go.mod h1:UCu8dlHqvkAsmAFmWDRWNZJPlu6ya2fTWZlDrWsivwo=
 github.com/cometbft/cometbft-db v0.14.1 h1:SxoamPghqICBAIcGpleHbmoPqy+crij/++eZz3DlerQ=
 github.com/cometbft/cometbft-db v0.14.1/go.mod h1:KHP1YghilyGV/xjD5DP3+2hyigWx0WTp9X+0Gnx0RxQ=
 github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572/go.mod h1:Bpd0/3mZuaj6Sj+PqrmIquiOKy397AKGThQPaGzNXAQ=

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ https://docs.firmachain.org/master/node-and-validators-guide/run-a-full-node/ins
 Currently available tags:
 | Version | Tag
 | - | - |
+| v0.5.1 | `v0.5.1-patch2` |
+| v0.5.1 | `v0.5.1-patch` |
 | v0.5.1 | `v0.5.1` |
 | v0.5.0 | `v0.5.0-patch` |
 | v0.5.0 | `v0.5.0` |


### PR DESCRIPTION
# Pull Request for Firmachain v0.5.1-patch2 Release

## Updates

### Chain Binary
- Upgrade: `v0.5.1-patch` → `v0.5.1-patch2`
- Since this patch is a **non-breaking, non-governance upgrade**, the chain version stays at `v0.5.1`

### Patches
**CometBFT Security Fix**
- **Issue**: A security vulnerability was identified in CometBFT, a core module of Cosmos.
- **Solution**: Applied the upstream fix in `v0.5.1-patch2` to mitigate the vulnerability.
- **CometBFT (Consensus)** : v0.38.18 -> v0.38.21

### Requirements

- **Go**: v1.21 (same as v0.5.1)

### Tests

- **Local**: Unit Tests, CLI Commands  
- **Devnet**: Unit Tests, CLI Commands, E2E Tests  
- **Testnet (Imperium-4)**: Unit Tests, CLI Commands, E2E Tests, Smart Contract Transactions (state-sync validation)


## Detailed Description

This patch addresses a security vulnerability in CometBFT, a core module of Cosmos.

Key improvements:
- Mitigates the CometBFT security issue in the Firmachain binary.
- Improves node safety without changing consensus or governance.


## Who Should Upgrade

- **Required**:
  - All node operators and validators (patch highly recommended)

- **Recommended**:
  - All validators and full nodes (upgrading improves overall safety)